### PR TITLE
specs: link to local, not IETF, specs

### DIFF
--- a/spec.md
+++ b/spec.md
@@ -11,8 +11,8 @@ The specification for JMAP has now been split into several parts so it's not qui
 
 There are four specifications:
 
-* [The core protocol](https://tools.ietf.org/html/rfc8620)
-* [JMAP Mail](https://tools.ietf.org/html/rfc8621)
+* [The core protocol](spec-core.html)
+* [JMAP Mail](spec-mail.html)
 * [JMAP Contacts](spec-contacts.html)
 * [JMAP Calendars](spec-calendars.html)
 


### PR DESCRIPTION
The IETF specs are harder to read and do not include fixes to
small errors.  Instead you need to go consult separate errata
documents, which is tedious.