### PR TITLE
Jmap news standard proposed

### DIFF
--- a/news.md
+++ b/news.md
@@ -5,6 +5,18 @@ title: JMAP News
 ---
 # JMAP News
 
+## JMAP as RFC 8260 (Proposed Standard)
+
+14 December 2019 / JMAP Community
+
+> [On 18 July 2019](https://twitter.com/Fastmail/status/1152281229083009025), the Internet Engineering Task Force ([IETF](https://ietf.org/about)), the first Internet standards body, developing open standards through open processes, published the public specifications for JMAP as [RFC 8260](https://tools.ietf.org/html/rfc8260), 
+the next standard for e-mail protocols, it makes JMAP the true open and modern standard to [replace IMAP and SMTP](https://www.coywolf.news/email/jmap-open-standard/) that is not hindered by proprietary protocols. These published specifications are important because the IETF, a trusted publisher, reviews, refines and publishes high quality, fully open technical specifications that enable [web interoperability](https://www.coywolf.news/email/jmap-open-standard/).
+
+> Emphasizing that open standards are [the engine of the power of the Internet](https://fastmail.blog/2019/08/16/jmap-new-email-open-standard/), JMAP standards are also open and have properties [that resolve the limitations](https://hub.packtpub.com/ietf-proposes-json-meta-application-protocol-jmap-as-the-next-standard-for-email-protocols/) encountered in current standards, making communication with mail servers [faster and more secure](https://www.coywolf.news/email/jmap-open-standard/). Here are some of the stunning benefits of JMAP: better for mobile environments, longer battery life for mobile users through query grouping, determination of the amount of data the server is allowed to send, a backward compatible data model, etc. 
+
+> JMAP standards simply make life easier for developers and allow [efficient use of network resources](https://hub.packtpub.com/ietf-proposes-json-meta-application-protocol-jmap-as-the-next-standard-for-email-protocols/).
+  Its standards ensure the proper functioning of the Internet, making it more useful, a demonstration of a great victory for email tools today and in the future. The published specifications have therefore [introduced JMAP to the world!](https://fastmail.blog/2019/08/16/jmap-new-email-open-standard/)
+
 ## K-9 Mail is working on adding JMAP support 
 
 15 November 2019 / JMAP Community

--- a/news.md
+++ b/news.md
@@ -5,17 +5,17 @@ title: JMAP News
 ---
 # JMAP News
 
-## JMAP as RFC 8260 (Proposed Standard)
+## JMAP as “Proposed Standard”
 
-14 December 2019 / JMAP Community
+30 December 2019 / JMAP Community
 
-> [On 18 July 2019](https://twitter.com/Fastmail/status/1152281229083009025), the Internet Engineering Task Force ([IETF](https://ietf.org/about)), the first Internet standards body, developing open standards through open processes, published the public specifications for JMAP as [RFC 8260](https://tools.ietf.org/html/rfc8260), 
+> [On 18 July 2019](https://twitter.com/Fastmail/status/1152281229083009025), the Internet Engineering Task Force ([IETF](https://ietf.org/about)), the first Internet standards body, developing open standards through open processes, published the public specifications for JMAP as [RFC 8620](https://tools.ietf.org/html/rfc8620), 
 the next standard for e-mail protocols, it makes JMAP the true open and modern standard to [replace IMAP and SMTP](https://www.coywolf.news/email/jmap-open-standard/) that is not hindered by proprietary protocols. These published specifications are important because the IETF, a trusted publisher, reviews, refines and publishes high quality, fully open technical specifications that enable [web interoperability](https://www.coywolf.news/email/jmap-open-standard/).
 
 > Emphasizing that open standards are [the engine of the power of the Internet](https://fastmail.blog/2019/08/16/jmap-new-email-open-standard/), JMAP standards are also open and have properties [that resolve the limitations](https://hub.packtpub.com/ietf-proposes-json-meta-application-protocol-jmap-as-the-next-standard-for-email-protocols/) encountered in current standards, making communication with mail servers [faster and more secure](https://www.coywolf.news/email/jmap-open-standard/). Here are some of the stunning benefits of JMAP: better for mobile environments, longer battery life for mobile users through query grouping, determination of the amount of data the server is allowed to send, a backward compatible data model, etc. 
 
 > JMAP standards simply make life easier for developers and allow [efficient use of network resources](https://hub.packtpub.com/ietf-proposes-json-meta-application-protocol-jmap-as-the-next-standard-for-email-protocols/).
-  Its standards ensure the proper functioning of the Internet, making it more useful, a demonstration of a great victory for email tools today and in the future. The published specifications have therefore [introduced JMAP to the world!](https://fastmail.blog/2019/08/16/jmap-new-email-open-standard/)
+  Its standards ensure the proper functioning of the Internet, making it more useful, a demonstration of a great victory for email tools today and in the future. The published specifications, [RFC 8620](https://tools.ietf.org/html/rfc8620), on July 18 2019, and [RFC 8621](https://tools.ietf.org/html/rfc8621), on August 13 2019, have therefore [introduced JMAP to the world!](https://fastmail.blog/2019/08/16/jmap-new-email-open-standard/)
 
 ## K-9 Mail is working on adding JMAP support 
 

--- a/news.md
+++ b/news.md
@@ -5,6 +5,18 @@ title: JMAP News
 ---
 # JMAP News
 
+## K-9 Mail is working on adding JMAP support 
+
+15 November 2019 / JMAP Community
+
+> JMAP is in constant evolution, it has a lot to offer, especially on mobile devices for which IMAP has not been designed. Since its creation, more and more solutions have already supported it or are considering integrating it as a protocol. This is the case of [K-9 Mail](https://k9mail.github.io/) which is an open source email client for Android with many advanced features. 
+
+>This was first announced as a proposed idea on K-9 Mail's proposed ideas page for [application for the Google Summer of Code 2017](https://github.com/k9mail/k-9/wiki/Google-Summer-of-Code-2017#jmap).
+Then, in September 2019, in a [comment](https://github.com/k9mail/k-9/issues/3272#issuecomment-528326161), [Cketti](https://github.com/cketti) indicated a possible work on the JMAP support for 6 months from September.
+
+> Moreover, through his [another comment](https://gitter.im/apache/james-project?at=5d766ca4c5939027203eb09d) of September 09, 2019, we can understand that the project is no longer in the proposed idea stage, but that he is already working on adding JMAP support to K-9 Mail.
+> Find the list of [solutions](https://jmap.io/software.html) that already support JMAP and those that are already working on it.
+
 ## JMAP Barcamp 2019
 
 2 July 2019 / Tuan LE CONG


### PR DESCRIPTION
Proposing to add the news about the publication of JMAP specifications by the Internet Engineering Task Force.