### PR TITLE
Add reference to quotas spec

### DIFF
--- a/spec-quotas.md
+++ b/spec-quotas.md
@@ -1,0 +1,18 @@
+---
+layout: default
+permalink: /spec-quotas.html
+title: JMAP Quotas Specification
+---
+
+# JMAP Quotas
+
+This specification defines a data model for handling quotas, allowing you to read and explain quota information using [JMAP](spec-core.html).
+
+{% capture x %}{% include spec/quotas/intro.mdown %}{% endcapture %}
+{{ x | replace: "# ", "## " | markdownify }}
+{% capture x %}{% include spec/quotas/quota.mdown %}{% endcapture %}
+{{ x | replace: "# ", "## " | markdownify }}
+{% capture x %}{% include spec/quotas/securityconsiderations.mdown %}{% endcapture %}
+{{ x | replace: "# ", "## " | markdownify }}
+{% capture x %}{% include spec/quotas/ianaconsiderations.mdown %}{% endcapture %}
+{{ x | replace: "# ", "## " | markdownify }}

--- a/spec.md
+++ b/spec.md
@@ -23,6 +23,7 @@ These specs are not yet final and will change before publication. There are undo
 * [JMAP Sharing](spec-sharing.html)
 * [JMAP Contacts](spec-contacts.html)
 * [JMAP Tasks](spec-tasks.html)
+* [JMAP Quotas](spec-quotas.html)
 
 ## Data formats
 


### PR DESCRIPTION
Hello,

I would like to have the quotas spec added to the in development section of the website jmap.io, thus the proposed PR.

I didn't see any README explaining how the website was compiled and deployed, so I'm very unsure if the code is good or not as I could not test it (was mainly done by deduction).

Let me know if it's ok or not, or how to test it if I have to make some changes.

Cheers!