### PR TITLE
Add shipmail to software list

### DIFF
--- a/pages/software.liquid
+++ b/pages/software.liquid
@@ -129,6 +129,13 @@ sections:
                 A proxy to do HTTP basic auth from a JWT token and redis
                 session credentials; built to add JWT bearer auth support to
                 Cyrus's JMAP.
+          - title: shipmail
+            href: https://shipmail.to/
+            license: Proprietary
+            body: >-
+                Email OS for founders and small teams with custom-domain
+                mailboxes, shared inboxes, routing, webmail, IMAP, JMAP and API
+                access.
           - title: Stalwart
             href: https://github.com/stalwartlabs/stalwart
             languages: [Rust]


### PR DESCRIPTION
Adds shipmail to the JMAP software page.

shipmail is an Email OS for founders and small teams with custom-domain mailboxes, shared inboxes, routing, webmail, IMAP, JMAP, and API access.

Validation:
- npx prettier --check pages/software.liquid