### PR TITLE
Add xin to software list

### DIFF
--- a/pages/software.liquid
+++ b/pages/software.liquid
@@ -92,6 +92,15 @@ sections:
             href: https://github.com/linagora/tmail-flutter
             languages: [Dart]
             body: Android, iOS and web client.
+          - title: xin
+            href: https://github.com/onevcat/xin
+            languages: [Rust]
+            license: MIT
+            body: >-
+                AI-first JMAP command line client built for LLM agents and
+                automation (Fastmail-first). Emits stable JSON by default and
+                covers search, read, send, drafts, labels, batch actions and a
+                streaming watch mode for inbox changes.
     - label: Servers
       items:
           - title: Apache James


### PR DESCRIPTION
Adds [xin](https://github.com/onevcat/xin) to the JMAP software page (Clients section).

xin is an **AI-first** JMAP command line client (Fastmail-first), purpose-built for LLM agents and automation rather than human use:

- Emits **stable JSON by default** (no flag needed) so agents can pipe through `jq` or feed results into tools.
- Covers search, read, send, drafts, labels, batch actions, and a streaming `watch` mode for inbox changes.
- Ships with copy/paste agent recipes (inbox triage, batch archive, inbox-zero helpers).
- Written in Rust, MIT-licensed, installable via Homebrew (`brew install onevcat/tap/xin`).

Validation:
- `npx prettier --check pages/software.liquid`
