### PR TITLE
Add Boogie and jmapcli to the software list

### DIFF
--- a/pages/software.liquid
+++ b/pages/software.liquid
@@ -29,6 +29,15 @@ sections:
             href: https://aerc-mail.org/
             languages: [Go]
             body: A terminal email client for the discerning hacker.
+          - title: Boogie
+            href: https://boogie.digital/
+            languages: [Swift]
+            license: Proprietary
+            body: >-
+                A native JMAP email and calendar client for Apple platforms —
+                macOS, iOS, iPadOS and watchOS. Built from scratch in pure
+                Swift with zero dependencies, privacy-first by default,
+                designed for Stalwart Mail Server and open email standards.
           - title: Bulwark Webmail
             href: https://bulwarkmail.org/
             languages: [Next.js]
@@ -241,6 +250,15 @@ sections:
             href: https://metacpan.org/pod/JMAP::Tester
             languages: [Perl, Perl5]
             body: A JMAP client made for testing JMAP servers.
+          - title: jmapcli
+            href: https://boogie.digital/cli/
+            languages: [Swift]
+            license: Proprietary
+            body: >-
+                A fast, native macOS command-line JMAP client. Send, read,
+                search, sync and manage mail from the terminal; installs via
+                Homebrew. Works with any JMAP server (Stalwart, Fastmail,
+                Cyrus).
           - title: mjmap
             href: https://git.sr.ht/~rockorager/mjmap
             languages: [Go]


### PR DESCRIPTION
Adds two JMAP clients to the software page:

- **Boogie** (Clients) — native JMAP email + calendar client for macOS / iOS / iPadOS / watchOS.
- **jmapcli** (Tools) — native macOS command-line JMAP client.

Both were previously merged into `software/software.mdown` (#433, #434). As noted there, the website no longer builds from that list, so this adds them to `pages/software.liquid`. Entries follow the existing format, fields, and alphabetical placement; descriptions match the merged ones.