### PR TITLE
 Add Sterna Mail (native Android JMAP+IMAP client)

### DIFF
--- a/pages/software.liquid
+++ b/pages/software.liquid
@@ -88,6 +88,14 @@ sections:
             href: https://github.com/linagora/tmail-flutter
             languages: [Dart]
             body: Android, iOS and web client.
+          - title: Sterna Mail
+            href: https://codeberg.org/emon/sterna-mail
+            languages: [Kotlin]
+            license: GPLv3
+            body: >-
+                A private, native Android email client for JMAP, with full
+                IMAP/SMTP support. No Google services, push without FCM,
+                multi-account unified inbox. Tested against Stalwart.
     - label: Servers
       items:
           - title: Apache James


### PR DESCRIPTION
Native Android (Kotlin/Compose) JMAP client with full IMAP/SMTP, FOSS (GPLv3), no Google services. Tested against Stalwart. Source: https://codeberg.org/emon/sterna-mail